### PR TITLE
fix(eslint/js): allow unused var when leading underscore

### DIFF
--- a/src/eslint/src/rules/variables.ts
+++ b/src/eslint/src/rules/variables.ts
@@ -27,5 +27,13 @@ export default {
   "no-undefined": "off",
 
   // See: https://eslint.org/docs/rules/no-unused-vars
-  "no-unused-vars": ["error", { "ignoreRestSiblings": true }]
+  "no-unused-vars": ["error", {
+    "args": "all",
+    "argsIgnorePattern": "^_",
+    "caughtErrors": "all",
+    "caughtErrorsIgnorePattern": "^_",
+    "destructuredArrayIgnorePattern": "^_",
+    "varsIgnorePattern": "^_",
+    "ignoreRestSiblings": true
+  }]
 };

--- a/src/eslint/test/fixtures/pass.ts
+++ b/src/eslint/test/fixtures/pass.ts
@@ -1,2 +1,6 @@
 const foo: string = "bar";
 console.log(foo);
+function _shouldPassEvenIfNotUsedDueToLeading_(_boo: any) {
+  console.log("bar");
+}
+const _shadow = "foo";


### PR DESCRIPTION
See https://github.com/NodeSecure/ci/pull/168

> Error:   7:12  error  '_payload' is defined but never used  no-unused-vars