### PR TITLE
fix: disallow template literals when unnecessary

### DIFF
--- a/src/eslint/src/rules/styles.ts
+++ b/src/eslint/src/rules/styles.ts
@@ -248,7 +248,7 @@ export default {
     "error",
     "double",
     {
-      allowTemplateLiterals: true
+      allowTemplateLiterals: "avoidEscape"
     }
   ],
 

--- a/src/eslint/src/rules/typescript.ts
+++ b/src/eslint/src/rules/typescript.ts
@@ -43,7 +43,7 @@ export default {
     "error",
     "double",
     {
-      allowTemplateLiterals: true
+      allowTemplateLiterals: "avoidEscape"
     }
   ],
   "@stylistic/semi": ["error", "always"],


### PR DESCRIPTION
To complete issue #88