### PR TITLE
feat(eslint): add no-legacy-dirname-filename rule

### DIFF
--- a/.changeset/legal-moments-live.md
+++ b/.changeset/legal-moments-live.md
@@ -1,0 +1,5 @@
+---
+"@openally/config.eslint": minor
+---
+
+Add no-legacy-dirname-filename custom rule

--- a/src/eslint/README.md
+++ b/src/eslint/README.md
@@ -46,7 +46,9 @@ export default [
 
 This package also includes the OpenAlly plugin custom rules, as follows:
 
+- [`@openally/constants`](./docs/constants.md)
 - [`@openally/imports`](./docs/imports.md)
+- [`@openally/no-legacy-dirname-filename`](./docs/no-legacy-dirname-filename.md)
 
 ### Globals
 

--- a/src/eslint/docs/no-legacy-dirname-filename.md
+++ b/src/eslint/docs/no-legacy-dirname-filename.md
@@ -1,0 +1,22 @@
+# ESLint Rule: `no-legacy-dirname-filename`
+
+This rule disallows legacy `__dirname` and `__filename` ESM patterns in favor of `import.meta.dirname` and `import.meta.filename` (added in Node.js v20.11.0, v21.2.0).
+
+---
+
+## ❌ Incorrect Code Examples
+
+```js
+import path from "node:path";
+import url from "node:url";
+
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+```
+
+## ✅ Correct Code Example
+
+```js
+import.meta.filename;
+import.meta.dirname;
+```

--- a/src/eslint/src/customRules/index.ts
+++ b/src/eslint/src/customRules/index.ts
@@ -1,8 +1,10 @@
 // Import Internal Dependencies
 import { rule as importsRule } from "./import.ts";
 import { rule as constantsRule } from "./constants.ts";
+import { rule as noLegacyDirnameFilenameRule } from "./no-legacy-dirname-filename.ts";
 
 export const rules = {
   imports: importsRule,
-  constants: constantsRule
+  constants: constantsRule,
+  "no-legacy-dirname-filename": noLegacyDirnameFilenameRule
 };

--- a/src/eslint/src/customRules/no-legacy-dirname-filename.ts
+++ b/src/eslint/src/customRules/no-legacy-dirname-filename.ts
@@ -1,0 +1,59 @@
+// Import Node.js Dependencies
+import path from "node:path";
+
+// Import Third-party Dependencies
+import type { TSESTree } from "@typescript-eslint/types";
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/OpenAlly/configs/tree/main/src/eslint/docs/${name}.md`
+);
+
+const kCjsExtensions = new Set([".cjs", ".cts"]);
+
+export const rule = createRule({
+  create(context) {
+    const extension = path.extname(context.filename);
+
+    if (kCjsExtensions.has(extension)) {
+      return {};
+    }
+
+    return {
+      "VariableDeclaration[kind=const] > VariableDeclarator:has(MemberExpression[property.name='url'] > MetaProperty)"(
+        node: TSESTree.VariableDeclarator
+      ) {
+        if (node.id.type !== "Identifier") {
+          return;
+        }
+
+        const { name } = node.id;
+        if (name === "__filename") {
+          context.report({
+            node: node.parent,
+            messageId: "preferImportMetaFilename"
+          });
+        }
+        else if (name === "__dirname") {
+          context.report({
+            node: node.parent,
+            messageId: "preferImportMetaDirname"
+          });
+        }
+      }
+    };
+  },
+  name: "no-legacy-dirname-filename",
+  meta: {
+    docs: {
+      description: "Disallow legacy __dirname and __filename patterns in favor of import.meta.dirname and import.meta.filename"
+    },
+    messages: {
+      preferImportMetaFilename: "Use 'import.meta.filename' instead of 'url.fileURLToPath(import.meta.url)'",
+      preferImportMetaDirname: "Use 'import.meta.dirname' instead of 'path.dirname(url.fileURLToPath(import.meta.url))'"
+    },
+    type: "suggestion",
+    schema: []
+  },
+  defaultOptions: []
+});

--- a/src/eslint/src/rules/openally.ts
+++ b/src/eslint/src/rules/openally.ts
@@ -1,4 +1,5 @@
 export default {
   "@openally/imports": ["error"],
-  "@openally/constants": ["error"]
+  "@openally/constants": ["error"],
+  "@openally/no-legacy-dirname-filename": ["error"]
 };

--- a/src/eslint/test/customRules/no-legacy-dirname-filename.test.ts
+++ b/src/eslint/test/customRules/no-legacy-dirname-filename.test.ts
@@ -1,0 +1,72 @@
+// Import Node.js Dependencies
+import { after, describe, it } from "node:test";
+
+// Import Third-party Dependencies
+import { RuleTester } from "@typescript-eslint/rule-tester";
+
+// Import Internal Dependencies
+import { rule } from "../../src/customRules/no-legacy-dirname-filename.ts";
+
+RuleTester.afterAll = after;
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const ruleTester = new RuleTester();
+ruleTester.run("no-legacy-dirname-filename", rule, {
+  valid: [
+    {
+      code: "const __dirname = import.meta.dirname;"
+    },
+    {
+      code: "const __filename = import.meta.filename;"
+    },
+    {
+      // CJS file should be ignored
+      code: "const __filename = url.fileURLToPath(import.meta.url);",
+      filename: "foo.cjs"
+    },
+    {
+      // CTS file should be ignored
+      code: "const __dirname = path.dirname(url.fileURLToPath(import.meta.url));",
+      filename: "foo.cts"
+    },
+    {
+      // Only targets __dirname/__filename declarations
+      code: "const foo = { bar: path.dirname(url.fileURLToPath(import.meta.url)) };"
+    }
+  ],
+  invalid: [
+    {
+      code: "const __filename = url.fileURLToPath(import.meta.url);",
+      errors: [{ messageId: "preferImportMetaFilename" }]
+    },
+    {
+      code: "const __filename = fileURLToPath(import.meta.url);",
+      errors: [{ messageId: "preferImportMetaFilename" }]
+    },
+    {
+      code: "const __dirname = path.dirname(url.fileURLToPath(import.meta.url));",
+      errors: [{ messageId: "preferImportMetaDirname" }]
+    },
+    {
+      code: "const __dirname = dirname(fileURLToPath(import.meta.url));",
+      errors: [{ messageId: "preferImportMetaDirname" }]
+    },
+    {
+      code: "const __filename = url.fileURLToPath(import.meta.url);",
+      filename: "foo.mjs",
+      errors: [{ messageId: "preferImportMetaFilename" }]
+    },
+    {
+      code: "const __dirname = path.dirname(url.fileURLToPath(import.meta.url));",
+      filename: "foo.ts",
+      errors: [{ messageId: "preferImportMetaDirname" }]
+    },
+    {
+      code: "const __filename = url.fileURLToPath(import.meta.url);",
+      filename: "foo.mts",
+      errors: [{ messageId: "preferImportMetaFilename" }]
+    }
+  ]
+});


### PR DESCRIPTION
Goal is to help migrate legacy `__dirname`/`__filename` patterns.