### PR TITLE
feat(eslint): add preserve-caught-error and no-unassigned-vars rules

### DIFF
--- a/.changeset/fair-singers-joke.md
+++ b/.changeset/fair-singers-joke.md
@@ -1,0 +1,5 @@
+---
+"@openally/config.eslint": minor
+---
+
+Add preserve-caught-error and no-unassigned-vars rules

--- a/src/eslint/src/rules/best-practices.ts
+++ b/src/eslint/src/rules/best-practices.ts
@@ -213,5 +213,8 @@ export default {
   "@stylistic/wrap-iife": "error",
 
   // See: https://eslint.org/docs/rules/yoda
-  yoda: "error"
+  yoda: "error",
+
+  // See: https://eslint.org/docs/rules/preserve-caught-error
+  "preserve-caught-error": "error"
 };

--- a/src/eslint/src/rules/variables.ts
+++ b/src/eslint/src/rules/variables.ts
@@ -5,6 +5,9 @@ export default {
   // See: https://eslint.org/docs/rules/no-delete-var
   "no-delete-var": "error",
 
+  // See: https://eslint.org/docs/rules/no-unassigned-vars
+  "no-unassigned-vars": "error",
+
   // See: https://eslint.org/docs/rules/no-label-var
   "no-label-var": "error",
 


### PR DESCRIPTION
Note: these 2 rules are the only missing rules found after running the sync script.

I think `no-unassigned-vars` is safe. 
`preserve-caught-error` may cause some errors, but it looks like a good rule to have.